### PR TITLE
Replace minimatch with path.matchesGlob

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ This action determines the exit code based on the condition at the timeout.
 
 If `timeout-seconds` is not set, this action waits forever until the condition is met.
 
+### Filter deployments
+
+You can set glob patterns to filter deployments by environment or task.
+It supports multiple patterns separated by newlines.
+It also supports negation patterns.
+For example,
+
+```yaml
+with:
+  filter-environments: |
+    pr-*
+    !pr-123
+```
+
+If both `filter-environments` and `exclude-environments` are set, this action applies `exclude-environments` first and then applies `filter-environments`.
+
 ## Specification
 
 ### Inputs

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "@actions/core": "3.0.1",
     "@octokit/action": "8.0.4",
     "@octokit/plugin-retry": "8.1.0",
-    "graphql": "16.14.1",
-    "minimatch": "10.2.5"
+    "graphql": "16.14.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       graphql:
         specifier: 16.14.1
         version: 16.14.1
-      minimatch:
-        specifier: 10.2.5
-        version: 10.2.5
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.16

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
-import * as minimatch from 'minimatch'
 import type { ListDeploymentsQuery } from './generated/graphql.js'
 import { DeploymentState } from './generated/graphql-types.js'
+import { matchesGlob } from 'node:path'
 
 export type Rollup = {
   conclusion: RollupConclusion
@@ -49,34 +49,35 @@ export type FilterOptions = {
 }
 
 export const filterDeployments = (deployments: Deployment[], options: FilterOptions): Deployment[] => {
-  const excludeEnvironmentMatchers = options.excludeEnvironments.map((pattern) => minimatch.filter(pattern))
-  const filterEnvironmentMatchers = options.filterEnvironments.map((pattern) => minimatch.filter(pattern))
-  const filterTaskMatchers = options.filterTasks.map((pattern) => minimatch.filter(pattern))
-  deployments = deployments.filter((deployment) => {
-    if (excludeEnvironmentMatchers.length > 0) {
-      if (excludeEnvironmentMatchers.some((matcher) => matcher(deployment.environment))) {
-        return false
-      }
-    }
-    if (filterEnvironmentMatchers.length > 0) {
-      if (!filterEnvironmentMatchers.some((matcher) => matcher(deployment.environment))) {
-        return false
-      }
-    }
-    if (filterTaskMatchers.length > 0) {
-      const task = deployment.task
-      if (task === undefined) {
-        return false
-      }
-      if (!filterTaskMatchers.some((matcher) => matcher(task))) {
-        return false
-      }
-    }
-    return true
-  })
+  const excludeEnvironmentMatchers = createGlobMatcher(options.excludeEnvironments, false)
+  const filterEnvironmentMatchers = createGlobMatcher(options.filterEnvironments)
+  const filterTaskMatchers = createGlobMatcher(options.filterTasks)
+  deployments = deployments.filter(
+    (deployment) =>
+      !excludeEnvironmentMatchers(deployment.environment) &&
+      filterEnvironmentMatchers(deployment.environment) &&
+      filterTaskMatchers(deployment.task ?? ''),
+  )
   deployments = sortByEnvironment(deployments)
   return deployments
 }
+
+const createGlobMatcher =
+  (patterns: string[], defaultValue = true) =>
+  (target: string): boolean => {
+    if (patterns.length === 0) {
+      return defaultValue
+    }
+    let matched = false
+    for (const pattern of patterns) {
+      if (pattern.startsWith('!')) {
+        matched = matched && !matchesGlob(target, pattern.slice(1))
+      } else {
+        matched = matched || matchesGlob(target, pattern)
+      }
+    }
+    return matched
+  }
 
 const sortByEnvironment = (deployments: Deployment[]) =>
   deployments.sort((a, b) => a.environment.localeCompare(b.environment))

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
+import { matchesGlob } from 'node:path'
 import type { ListDeploymentsQuery } from './generated/graphql.js'
 import { DeploymentState } from './generated/graphql-types.js'
-import { matchesGlob } from 'node:path'
 
 export type Rollup = {
   conclusion: RollupConclusion


### PR DESCRIPTION
Node.js 24 ships `path.matchesGlob` natively, making the `minimatch` dependency redundant.
